### PR TITLE
Corrections and improvements

### DIFF
--- a/draft-zyp-json-schema-03.xml
+++ b/draft-zyp-json-schema-03.xml
@@ -8,6 +8,7 @@
 <!ENTITY rfc3339 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3339.xml">
 <!ENTITY rfc2045 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2045.xml">
 <!ENTITY rfc5226 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5226.xml">
+<!ENTITY rfc2396 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2396.xml">
 <!ENTITY iddiscovery SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.hammer-discovery.xml">
 <!ENTITY uritemplate SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.gregorio-uritemplate.xml">
 <!ENTITY linkheader SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.nottingham-http-link-header.xml">
@@ -22,10 +23,8 @@
 <?rfc rfcedstyle="yes"?>
 <rfc category="info" docName="draft-zyp-json-schema-03" ipr="trust200902">
   <front>
-    
 
     <title abbrev="JSON Schema Media Type">A JSON Media Type for Describing the Structure and Meaning of JSON Documents</title>
-
 
     <author fullname="Kris Zyp" initials="K" role="editor"
             surname="Zyp">
@@ -45,23 +44,33 @@
         <email>kris@sitepen.com</email>
       </address>
     </author>
+    
+    <author fullname="Gary Court" initials="G" surname="Court">
+      <address>
+        <postal>
+          <city>Calgary, AB</city>
+          <country>Canada</country>
+        </postal>
+        <email>gary.court@gmail.com</email>
+      </address>
+    </author>
 
     <date year="2010" />
 
     <workgroup>Internet Engineering Task Force</workgroup>
 
     <keyword>JSON</keyword>
-
     <keyword>Schema</keyword>
-
+    <keyword>JavaScript</keyword>
+    <keyword>Object</keyword>
+    <keyword>Notation</keyword>
     <keyword>Hyper Schema</keyword>
-
     <keyword>Hypermedia</keyword>
 
     <!--[TODO] add additional keywords here for IETF website search engine -->
 
     <abstract>
-      <t>JSON (JavaScript Object Notation) Schema defines the media type application/schema+json, 
+      <t>JSON (JavaScript Object Notation) Schema defines the media type "application/schema+json", 
       a JSON based format for defining 
       the structure of JSON data. JSON Schema provides a contract for what JSON 
       data is required for a given application and how to interact with it. JSON 
@@ -87,13 +96,13 @@
                   and should not be modified.-->The key words "MUST", "MUST
       NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
       "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-      interpreted as described in RFC 2119.</t>
+      interpreted as described in <xref target='RFC2119'>RFC 2119</xref>.</t>
     </section>
 
     <!-- ********************************************* -->
 
     <section title="Overview">
-      <t>JSON Schema defines the media type application/schema+json for 
+      <t>JSON Schema defines the media type "application/schema+json" for 
       describing the structure of other
       JSON documents. JSON Schema is JSON-based and includes facilities 
       for describing the structure of JSON documents in terms of
@@ -118,8 +127,7 @@
 	<t>
 	An example JSON Schema that describes products might look like:
       <figure>
-        <artwork>
-        <![CDATA[	
+        <artwork><![CDATA[	
 {
   "name":"Product",
   "properties":{
@@ -139,7 +147,7 @@
       "optional":true,
       "type":"array",
       "items":{
-         "type":"string"
+        "type":"string"
       }
     }
   },
@@ -197,7 +205,7 @@ JSON documents.
 	<t>
 	JSON Schema instances are correlated to their schema by the "describedby"
 	relation, where the schema is defined to be the target of the relation.
-	Instance representations may be of the application/json media type or
+	Instance representations may be of the "application/json" media type or
 	any other subtype. Consequently, dictating how an instance
 	representation should specify the relation to the schema is beyond the normative scope
 	of this document (since this document specifically defines the JSON
@@ -210,16 +218,14 @@ JSON documents.
 	of instances) structure. A MIME type parameter named
 	"profile" or a relation of "describedby" (which could be defined by a Link header) may be used:
       <figure>
-        <artwork>
-        <![CDATA[	
+        <artwork><![CDATA[	
 Content-Type: application/my-media-type+json; 
               profile=http://json.com/my-hyper-schema
 ]]></artwork></figure>	
 	or if the content is being transferred by a protocol (such as HTTP) that
 	provides headers, a Link header can be used:
       <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 Link: <http://json.com/my-hyper-schema>; rel="describedby"
 ]]></artwork></figure>
 	Instances MAY specify multiple schemas, to indicate all the schemas that 
@@ -238,14 +244,13 @@ collection. However, ultimately, the mechanism for referencing a schema is up to
 	<t>
 	JSON Schemas are themselves instances for the schema 
 	schemas. A self-describing JSON Schema for the core JSON Schema can
-	be found at http://json-schema.org/schema and the hyper schema 
-	self-description can be found at: http://json-schema.org/hyper-schema. All schemas
+	be found at <eref target="http://json-schema.org/schema">http://json-schema.org/schema</eref>, while the hyper schema 
+	self-description can be found at <eref target="http://json-schema.org/hyper-schema">http://json-schema.org/hyper-schema</eref>. All schemas
 	used within a protocol with media type definitions
 	SHOULD include a MIME parameter that refers to the self-descriptive
 	hyper schema or another schema that extends this hyper schema:
       <figure>
-        <artwork>
-        <![CDATA[	
+        <artwork><![CDATA[	
 Content-Type: application/json; 
               profile=http://www.json-schema.org/hyper-schema
 ]]></artwork></figure>
@@ -255,28 +260,27 @@ Content-Type: application/json;
 	
       <section title="Core Schema Definition">
         <t>A JSON Schema is a JSON Object that defines various attributes 
-        of the instance and defines it's usage and valid values. A JSON 
-        Schema is a JSON Object with schema attribute properties. JSON
+        of the instance and defines it's usage and valid values. JSON
         Schema has recursive capabilities; there are a number of elements
         in the structure that allow for a nested JSON Schema or URI
         referencing a schema. Schema referencing URIs can be relative 
         or absolute and the target of the URI SHOULD be treated as 
         the schema for the given element in the schema structure.
-        The following is the grammar of a JSON Schema:
 	</t>
 
 
-	<t>And an example JSON Schema definition could look like:</t>
+	<t>An example JSON Schema definition could look like:</t>
       <figure>
-        <artwork>
-        <![CDATA[
-{"description":"A person",
- "type":"object",
+        <artwork><![CDATA[
+{
+  "description":"A person",
+  "type":"object",
 
- "properties":
-  {"name": {"type":"string"},
-   "age" : {"type":"integer",
-     "maximum":125}}
+  "properties":{
+    "name":{"type":"string"},
+    "age" :{"type":"integer"},
+    "maximum":125
+  }
 }     
 	]]></artwork>
 	</figure>
@@ -287,25 +291,29 @@ Content-Type: application/json;
 
 <section title="type">
 <t>
-<list><t>Union type definition - An array with two or more items which indicates a union of type definitions. Each item in the array MAY be a simple type definition, a schema, or a URI for a schema. The instance value is valid if it is of the same type as one the type definitions in the array or if it is valid by one of the schemas (or schema referenced by the URI) in the array. For example to indicate that a string or number is a valid:
-{"type":["string","number"]}</t>
-<t>Simple type definition - A string indicating a primitive or simple type. The following are acceptable strings:
+<list style="hanging">
+<t hangText="Simple type definition">A string indicating a primitive or simple type. The following are acceptable strings:
 
- 
-<list> 
-<t>string - Value MUST be a string.
-</t> 
-<t>number - Value MUST be a number, floating point numbers are allowed. </t> 
-<t>integer - Value MUST be an integer, no floating point numbers are allowed. This is a subset of the number type.</t> 
-<t>boolean - Value MUST be a boolean. </t> 
-<t>object - Value MUST be an object.</t> 
-<t>array - Value MUST be an array.
-</t> 
-<t>null - Value MUST be null. Note this is mainly for purpose of being able use union types to define nullability. If this type is not 
+<list style="hanging"> 
+<t hangText="string">Value MUST be a string.</t> 
+<t hangText="number">Value MUST be a number, floating point numbers are allowed. </t> 
+<t hangText="integer">Value MUST be an integer, no floating point numbers are allowed. This is a subset of the number type.</t> 
+<t hangText="boolean">Value MUST be a boolean. </t> 
+<t hangText="object">Value MUST be an object.</t> 
+<t hangText="array">Value MUST be an array.</t> 
+<t hangText="null">Value MUST be null. Note this is mainly for purpose of being able use union types to define nullability. If this type is not 
 included in a union, null values are not allowed (the primitives listed above do not allow nulls on their own).</t> 
-<t>any - Value MAY be of any type including null.
+<t hangText="any">Value MAY be of any type including null. 
 If the property is not defined or is not in this list, than any type of value is acceptable. Other type values MAY be used for custom purposes, but minimal validators of the specification implementation can allow any instance value on unknown type values.</t> 
 </list>
+</t>
+<t hangText="Union type definition">An array with two or more simple type definitions. Each item in the array MUST be a simple type definition, a schema, or a URI for a schema. The instance value is valid if it is of the same type as one the simple type definitions in the array, or if it is valid by one of the schemas (or schema referenced by the URI) in the array. 
+      <figure>
+        <preamble>For example, a schema that defines if an instance can be a string or a number would be:</preamble>
+        <artwork><![CDATA[
+{"type":["string","number"]}
+]]></artwork>
+</figure>
 </t>
 </list>
 </t>
@@ -323,21 +331,18 @@ If the property is not defined or is not in this list, than any type of value is
 <t>This provides a definition for additional items in array when tuple definition of the items in an array is provided. This can be false to indicate additional items in the array are not allowed, or it can be a schema or a URI referencing a schema to define the type of the additional items.</t>
 </section> 
 <section title="required">
-<t>This indicates that the instance property in the instance object is required. This is false by default.</t>
+<t>This attribute indicates if the instance must have a value, and not be undefined. This is false by default, making the instance optional.</t>
 </section> 
 <section title="requires">
-<t>This indicates that if this property is present in the containing instance object, the property given by requires attribute MUST also be present in the containing instance object. The value
+<t>This attribute indicates that if this property is present in the containing instance object, the property given by requires attribute MUST also be present in the containing instance object. The value
 of this property MAY be a string, indicating the require property name. Or the value MAY be a schema or a URI referencing a schema, in which case the containing instance MUST be valid by the schema if the property is present. For example if a object type definition is defined:</t>
       <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 { 
-  "state":
-  {
+  "state":{
     "optional":true
   },
-  "town":
-  {
+  "town":{
     "requires":"state",
     "optional":true
   }
@@ -347,63 +352,63 @@ of this property MAY be a string, indicating the require property name. Or the v
 <t>An instance MUST include a state property if a town property is included. If a town property is not included, the state property is optional.</t>
 </section> 
 <section title="minimum">
-<t>This indicates the minimum value for the instance property when the type of the instance value is a number.</t>
+<t>This attribute defines the minimum value of the instance property when the type of the instance value is a number.</t>
 </section> 
 <section title="maximum">
-<t>This indicates the maximum value for the instance property when the type of the instance value is a number.</t>
+<t>This attribute defines the maximum value of the instance property when the type of the instance value is a number.</t>
 </section> 
 <section title="exclusiveMinimum">
-<t>This indicates the minimum value for the instance property when the type of the instance value is a number. The instance value can not equal the exclusiveMinimum value.</t>
+<t>This attribute indicates if the value of the instance (if the instance is a number) can not equal the number defined by the "minimum" attribute. This is false by default, meaning the instance value can be greater then or equal to the minimum value.</t>
 </section> 
 <section title="exclusiveMaximum">
-<t>This indicates the maximum value for the instance property when the type of the instance value is a number. The instance value can not equal the exclusiveMaximum value.</t>
+<t>This attribute indicates if the value of the instance (if the instance is a number) can not equal the number defined by the "maximum" attribute. This is false by default, meaning the instance value can be less then or equal to the maximum value.</t>
 </section> 
 <section title="minItems">
-<t>This indicates the minimum number of values in an array when an array is the instance value.</t>
+<t>This attribute defines the minimum number of values in an array when the array is the instance value.</t>
 </section> 
 <section title="maxItems">
-<t>This indicates the maximum number of values in an array when an array is the instance value.</t>
+<t>This attribute defines the maximum number of values in an array when the array is the instance value.</t>
 </section> 
 <section title="uniqueItems">
-<t>This indicates that all the items in an array MUST be unique (no two identical values) within that array when an array is the instance value. Uniqueness is only defined for primitive values (strings, numbers, booleans, and nulls).</t>
+<t>This attribute indicates that all the items in an array MUST be unique (no two identical values) within that array when the array is the instance value. Uniqueness is only defined for primitive types: strings, numbers, booleans, and nulls.</t>
 </section> 
 <section title="pattern">
-<t>When the instance value is a string, this provides a regular expression that an instance string value MUST match in order to be valid. Regular expressions SHOULD follow the regular expression specification from ECMA 262/Perl 5</t></section>
+<t>When the instance value is a string, this provides a regular expression that a string instance MUST match in order to be valid. Regular expressions SHOULD follow the regular expression specification from ECMA 262/Perl 5</t></section>
 <section title="maxLength">
-<t>When the instance value is a string, this indicates maximum length of the string.</t>
+<t>When the instance value is a string, this defines the maximum length of the string.</t>
 </section> 
 <section title="minLength">
-<t>When the instance value is a string, this indicates minimum length of the string.</t>
+<t>When the instance value is a string, this defines the minimum length of the string.</t>
 </section> 
 <section title="enum">
-<t>This provides an enumeration of possible values that are valid for the instance property. This MUST be an array, and each item in the array represents a possible value for the instance value. If "enum" is included, the instance value MUST be one of the values in enum array in order for the schema to be valid.</t>
+<t>This provides an enumeration of possible values that are valid for the instance property. This MUST be an array, and each item in the array represents a possible value for the instance value. If this attribute is defined, the instance value MUST be one of the values in the array in order for the schema to be valid.</t>
 </section> 
 <section title="title">
-<t>This provides a short description of the instance property. The value MUST be a string.</t>
+<t>This attribute is a string that provides a short description of the instance property.</t>
 </section> 
 <section title="description">
-<t>This provides a full description of the of purpose the instance property. The value MUST be a string.</t>
+<t>This attribute is a string that provides a full description of the of purpose the instance property.</t>
 </section>
 
-<section title="format"><t>This property indicates the type of data, content type, or microformat to be expected in the instance property values. A format attribute MAY be one of the values listed below, and if so, SHOULD adhere to the semantics describing for the format. A format SHOULD only be used give meaning to primitive types (string, integer, number, or boolean). Validators are not required to validate that the instance values conform to a format. The following formats are defined:</t>
+<section title="format"><t>This property defines the type of data, content type, or microformat to be expected in the instance property values. A format attribute MAY be one of the values listed below, and if so, SHOULD adhere to the semantics describing for the format. A format SHOULD only be used give meaning to primitive types (string, integer, number, or boolean). Validators are not required to validate that the instance values conform to a format. The following formats are defined:</t>
 <t>  
-<list>
-<t>date-time - This SHOULD be a date in ISO 8601 format of YYYY-MM-DDThh:mm:ssZ in UTC time. This is the recommended form of date/timestamp.
-</t><t>date - This SHOULD be a date in the format of YYYY-MM-DD. It is recommended that you use the "date-time" format instead of "date" unless you need to transfer only the date part.
-</t><t>time - This SHOULD be a time in the format of hh:mm:ss. It is recommended that you use the "date-time" format instead of "time" unless you need to transfer only the time part.
-</t><t>utc-millisec - This SHOULD be the difference, measured in milliseconds, between the specified time and midnight, 00:00 of January 1, 1970 UTC. The value SHOULD be a number (integer or float).
-</t><t>regex - A regular expression, following the regular expression specification from ECMA 262/Perl 5.
-</t><t>color - This is a CSS color (like "#FF0000" or "red"), based on <xref target='W3C.CR-CSS21-20070719'>CSS 2.1</xref>.
-</t><t>style - This is a CSS style definition (like "color: red; background-color:#FFF"), based on <xref target='W3C.CR-CSS21-20070719'>CSS 2.1</xref>.
-</t><t>phone - This SHOULD be a phone number (format MAY follow E.123).
-</t><t>uri - This value SHOULD be a URI..
-</t><t>email - This SHOULD be an email address.
-</t><t>ip-address - This SHOULD be an ip version 4 address.
-</t><t>ipv6 - This SHOULD be an ip version 6 address.
-</t><t>host-name - This SHOULD be a host-name.</t>
-<t>Additional custom formats MAY be defined with a URL to a definition of the format.</t>
+<list style="hanging">
+<t hangText="date-time">This SHOULD be a date in ISO 8601 format of YYYY-MM-DDThh:mm:ssZ in UTC time. This is the recommended form of date/timestamp.
+</t><t hangText="date">This SHOULD be a date in the format of YYYY-MM-DD. It is recommended that you use the "date-time" format instead of "date" unless you need to transfer only the date part.
+</t><t hangText="time">This SHOULD be a time in the format of hh:mm:ss. It is recommended that you use the "date-time" format instead of "time" unless you need to transfer only the time part.
+</t><t hangText="utc-millisec">This SHOULD be the difference, measured in milliseconds, between the specified time and midnight, 00:00 of January 1, 1970 UTC. The value SHOULD be a number (integer or float).
+</t><t hangText="regex">A regular expression, following the regular expression specification from ECMA 262/Perl 5.
+</t><t hangText="color">This is a CSS color (like "#FF0000" or "red"), based on <xref target='W3C.CR-CSS21-20070719'>CSS 2.1</xref>.
+</t><t hangText="style">This is a CSS style definition (like "color: red; background-color:#FFF"), based on <xref target='W3C.CR-CSS21-20070719'>CSS 2.1</xref>.
+</t><t hangText="phone">This SHOULD be a phone number (format MAY follow E.123).
+</t><t hangText="uri">This value SHOULD be a URI..
+</t><t hangText="email">This SHOULD be an email address.
+</t><t hangText="ip-address">This SHOULD be an ip version 4 address.
+</t><t hangText="ipv6">This SHOULD be an ip version 6 address.
+</t><t hangText="host-name">This SHOULD be a host-name.</t>
 </list>
 </t>
+<t>Additional custom formats MAY be defined with a URL to a definition of the format.</t>
 </section> 
 <section title="maxDecimal">
 <t>This indicates the maximum number of decimal points.</t>
@@ -414,19 +419,19 @@ of this property MAY be a string, indicating the require property name. Or the v
 <section title="extends">
 <t>The value of this property MUST be another schema or a URI referencing a schema which will provide a base schema which the current schema will inherit from. The inheritance rules are such that any instance that is valid according to the current schema MUST be valid according to the referenced schema. This MAY also be an array, in which case, the instance MUST be valid for all the schemas in the array. A schema that extends another schema MAY define additional properties, constrain existing properties, or add other constraints. The schema MUST NOT define a constraint that conflicts with an extended schema such that no instance may satisfy both schemas. An example of using "extends":
       <figure>
-        <artwork>
-        <![CDATA[
-{"description":"An adult",
- "properties":{"age": {"minimum": 21}},
- "extends":"person"
+        <artwork><![CDATA[
+{
+  "description":"An adult",
+  "properties":{"age":{"minimum": 21}},
+  "extends":"person"
 }
 ]]></artwork></figure>
       <figure>
-        <artwork>
-        <![CDATA[
-{"description":"Extended schema",
- "properties":{"deprecated": {"type": "boolean"}},
- "extends":"http://json-schema.org/schema"
+        <artwork><![CDATA[
+{
+  "description":"Extended schema",
+  "properties":{"deprecated":{"type": "boolean"}},
+  "extends":"http://json-schema.org/schema"
 }
 ]]></artwork></figure>
 
@@ -435,7 +440,7 @@ of this property MAY be a string, indicating the require property name. Or the v
 </section> 
 <section title="id">
 <t>
-This indicates the URI of this schema (the target is effectively
+This defines the URI of this schema (the target is effectively
 the "self" relation). This MAY be a relative or absolute. If the URI
 is relative, it SHOULD be resolved against the URI used to retrieve this schema.
 </t>
@@ -466,13 +471,13 @@ values. The link description format can be used on its own in
 regular (non-schema documents), and use of this format can
 be declared by referencing the normative link description
 schema as the the schema for the data structure that uses the 
-links. The URI of the normative link description schema is: http://json-schema.org/links.
+links. The URI of the normative link description schema is: <eref target="http://json-schema.org/links">http://json-schema.org/links</eref>.
 </t>
 <section title="href">
     <t>
     The value of the "href" link description property
 indicates the target URI of the related resource. The value
-of the instance property SHOULD be resolved as a URI-Reference per [RFC3986]
+of the instance property SHOULD be resolved as a URI-Reference per <xref target='RFC3986'>RFC 3986</xref>
 and MAY be a relative URI. The base URI to be used for relative resolution
 SHOULD be the URI used to retrieve the instance object (not the schema)
 when used within a schema. Also, when links are used within a schema, the URI 
@@ -488,8 +493,7 @@ by using the text between the braces to denote the property name
 from the instance to get the value to substitute. For example,
 if an href value is defined:
       <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 http://somesite.com/{id}
 ]]></artwork>
 </figure>
@@ -497,8 +501,7 @@ Then it would be resolved by replace the value of the "id" property value from
 the instance object. If the value of the "id" property was "45", the expanded
 URI would be:
       <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 http://somesite.com/45
 ]]></artwork>
 </figure>
@@ -515,75 +518,75 @@ relation to the target resource. The relation to the target SHOULD be interprete
 </t>
 <t>
 Relationship definitions SHOULD NOT be media type dependent, and users are encouraged to utilize existing accepted relation definitions, including those in existing relation registries (see <xref target='RFC4287'>RFC 4287</xref>). However, we define these relation here for clarity of normative interpretation within the context of JSON hyper schema defined relations:
-<list>
-<t>
-self - If the relation value is "self", when this property is encountered in
+<list style="hanging">
+<t hangText="self">
+If the relation value is "self", when this property is encountered in
 the instance object, the object represents a resource and the instance object is
 treated as a full representation of the target resource identified by
 the specified URI.
 </t>
-<t>
-full - This indicates that the target of the link is the full representation for the instance object. The object that contains this link possibly may not be the full representation.
+<t hangText="full">
+This indicates that the target of the link is the full representation for the instance object. The object that contains this link possibly may not be the full representation.
 </t>
-<t>
-describedby - This indicates the target of the link is the schema for the instance object. This MAY be used to specifically denote the schemas of objects within a JSON object hierarchy, facilitating polymorphic type data structures.
+<t hangText="describedby">
+This indicates the target of the link is the schema for the instance object. This MAY be used to specifically denote the schemas of objects within a JSON object hierarchy, facilitating polymorphic type data structures.
 </t>
-<t>
-The following relations are applicable for schemas (the schema as the "from" resource in the relation).
-</t>
-<t>
-instances - This indicates the target resource that represents collection of instances of a schema. 
-</t>
-<t>
-create - This indicates a target to use for creating new instances of a schema. This link definition SHOULD be a submission link with a non-safe method (like POST).
-</t>
-<t>root - This relation indicates that the target 
+<t hangText="root">This relation indicates that the target of the link
 SHOULD be treated as the root or the body of the representation for the
-purposes of user agent interaction and fragment resolution (all other
+purposes of user agent interaction or fragment resolution. All other
 properties of the instance objects are can be regarded as meta-data
-descriptions for the data).
-
+descriptions for the data.
 </t>
-
 </list>
+</t>
+<t>
+The following relations are applicable for schemas (the schema as the "from" resource in the relation):
+<list style="hanging">
+<t hangText="instances">
+This indicates the target resource that represents collection of instances of a schema. 
+</t>
+<t hangText="create">
+This indicates a target to use for creating new instances of a schema. This link definition SHOULD be a submission link with a non-safe method (like POST).
+</t>
+</list>
+</t>
+<t>
 For example, if a schema is defined:
       <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 {
-    "links": [
-    	{
-    		"rel": "self"
-    		"href": "{id}"
-    	},
-    	{
-    		"rel": "up"
-    		"href": "{upId}"
-    	},
-    	{
-    		"rel": "children"
-    		"href": "?upId={id}"
-    	}
-    ]
+  "links": [
+    {
+      "rel": "self"
+      "href": "{id}"
+    },
+    {
+      "rel": "up"
+      "href": "{upId}"
+    },
+    {
+      "rel": "children"
+      "href": "?upId={id}"
+    }
+  ]
 }
 ]]></artwork>
 </figure>
 And if a collection of instance resource's JSON representation was
 retrieved:
     <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 GET /Resource/
 
 [
-    {
-        "id": "thing",
-        "upId": "parent"
-    },
-    {
-        "id": "thing2",
-        "upId": "parent"
-    }
+  {
+    "id": "thing",
+    "upId": "parent"
+  },
+  {
+    "id": "thing2",
+    "upId": "parent"
+  }
 ]
 ]]></artwork>
 </figure>
@@ -593,10 +596,10 @@ This would indicate that for the first item in the collection, it's own
 relation SHOULD be resolved to the resource at "/Resource/parent".
 The "children" collection would be located at "/Resource/?upId=thing".
 </t>
-<section title="targetSchema">
-<t>This property value can be a schema that defines the expected 
-structure of the JSON representation of the target of the link.</t>
 </section>
+<section title="targetSchema">
+<t>This property value is a schema that defines the expected 
+structure of the JSON representation of the target of the link.</t>
 </section>
 <section title="Submission Link Properties">
 <t>
@@ -607,7 +610,7 @@ means for submitting extra (often user supplied) information to send to a server
 <section title="method">
 <t>
 
-This indicates which method can be used to access the target resource. 
+This attribute defines which method can be used to access the target resource. 
 In an HTTP environment, this would be "GET" or "POST" (other HTTP methods 
 such as "PUT" and "DELETE" have semantics that are clearly implied by 
 accessed resources, and do not need to be defined here). 
@@ -625,33 +628,31 @@ property-based constraints on the resources that SHOULD be returned from
 the server or used to post data to the resource (depending on the method). 
 For example, with the following schema:
     <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 {
  "links":[
-    {
-      "enctype": "application/x-www-form-urlencoded",
-      "method": "GET",
-      "href": "/Product/",
-      "properties":{
-         "name":{"description":"name of the product"}
-      }
-    }
-  ]
+   {
+     "enctype":"application/x-www-form-urlencoded",
+     "method":"GET",
+     "href":"/Product/",
+     "properties":{
+        "name":{"description":"name of the product"}
+     }
+   }
+ ]
 }
 ]]></artwork>
 </figure>
 This indicates that the client can query the server for instances that
 have a specific name:
     <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 /Product/?name=Slinky
 ]]></artwork>
 </figure>
 
 If no enctype or method is specified, only the single URI specified by 
-the href property is defined. If the method is POST, application/json is 
+the href property is defined. If the method is POST, "application/json" is 
 the default media type.
 </t>
 </section>
@@ -680,7 +681,7 @@ document.
 
 </t>
 <t>
-The fragment identifier is based on RFC 2396 Sec 5, and defines the
+The fragment identifier is based on <xref target='RFC2396'>RFC 2396, Sec 5</xref>, and defines the
 mechanism for resolving references to entities within a document.
 </t>
 <section title="slash-delimited fragment resolution">
@@ -709,35 +710,33 @@ delimiter.
 <t>
 For example, for the following JSON representation:
     <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 {
-   "foo":{
-      "anArray":[
-        {"prop":44}
-      ],
-      "another prop":{
-          "baz":"A string"
-      }
-   }
+  "foo":{
+    "anArray":[
+      {"prop":44}
+    ],
+    "another prop":{
+      "baz":"A string"
+    }
+  }
 }
 ]]></artwork>
 </figure>
 The following fragment identifiers would be resolved:
     <figure>
-        <artwork>
-        <![CDATA[
-fragment identifier    resolution
--------------------    ----------
-#                      self, the root of the resource itself
-#/foo                  the object referred to by the foo property
-#/foo/another%20prop   the object referred to by the "another prop"
-                       property of the object referred to by the 
-                       "foo" property
-#/foo/another prop/baz the string referred to by the value of "baz"
-                       property of the "another prop" property of 
-                       the object referred to by the "foo" property
-#/foo/anArray/0        the first object in the "anArray" array
+        <artwork><![CDATA[
+fragment identifier      resolution
+-------------------      ----------
+#                        self, the root of the resource itself
+#/foo                    the object referred to by the foo property
+#/foo/another%20prop     the object referred to by the "another prop"
+                         property of the object referred to by the 
+                         "foo" property
+#/foo/another%20prop/baz the string referred to by the value of "baz"
+                         property of the "another prop" property of 
+                         the object referred to by the "foo" property
+#/foo/anArray/0          the first object in the "anArray" array
 ]]></artwork>
 </figure>
 </t>
@@ -754,24 +753,25 @@ identifiers for referencing the value of the foo propery.</t>
 </section>
 
 <section title="readonly">
-<t>This indicates that the instance property SHOULD NOT be changed. Attempts by a user agent to modify the value of this property are expected to be rejected by a server.</t>
+<t>This attribute indicates that the instance property SHOULD NOT be changed. Attempts by a user agent to modify the value of this property are expected to be rejected by a server.</t>
 </section> 
 <section title="contentEncoding"><t>
-If the instance property value is a string, this indicates that the string SHOULD be interpreted as binary data and decoded using the encoding named by this schema property. RFC 2045, Sec 6.1 lists possible values.
+If the instance property value is a string, this attribute defines that the string SHOULD be interpreted as binary data and decoded using the encoding named by this schema property. <xref target='RFC2045'>RFC 2045, Sec 6.1</xref> lists the possible values for this property.
 </t>
 </section>
 
 <section title="default">
-<t>This indicates the default for the instance property.</t>
+<t>This attribute defines the default value of the instance when the instance is undefined.</t>
 </section> 
 
-    <section title="pathStart">
-    <t>This property value is a URI-Reference that indicates the URI that all 
+<section title="pathStart">
+<t>
+This property value is a URI-Reference that indicates the URI that all 
 the URIs for the instances of the schema MUST start with. When 
 multiple schemas have been referenced for an instance, the user agent 
 can determine if this schema is applicable for a particular instance by 
 determining if URI of the instance begins with the pathStart's referenced 
-URI. pathStart MUST be resolved as per [RFC3986] section 5. If the URI of 
+URI. pathStart MUST be resolved as per <xref target='RFC3986'>RFC 3986, Sec 5</xref>. If the URI of 
 the instance does not start with URI indicated by pathStart, or if another 
 schema specifies a starting URI that is longer and also matches the 
 instance, this schema SHOULD NOT be applied to the instance. Any schema 
@@ -785,8 +785,9 @@ If this URI is relative, it should be resolved against the instance's URI.
 
 
 </section>
-    <section title="mediaType">
-    <t>This indicates the media type of the instance representations that this schema is defining.
+
+<section title="mediaType">
+<t>This attribute defines the media type of the instance representations that this schema is defining.
 </t>
 
 </section>
@@ -797,8 +798,8 @@ If this URI is relative, it should be resolved against the instance's URI.
 <section title="Security Considerations">
 <t>
 This specification is a sub-type of the JSON format, and 
-consequently the security considerations are generally the same as RFC
-4627. However, an additional issue is that when link relation of "self"
+consequently the security considerations are generally the same as <xref target='RFC4627'>RFC 4627</xref>. 
+However, an additional issue is that when link relation of "self"
 is used to denote a full representation of an object, the user agent 
 SHOULD NOT consider the representation to be the authoritative representation
 of the resource denoted by the target URI if the target URI is not
@@ -806,13 +807,12 @@ equivalent to or a sub-path of the the URI used to request the resource
 representation which contains the target URI with the "self" link.
 For example, if a hyper schema was defined:
     <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 {
   "links":[
   	{
-  		"rel":"self",
-  		"href":"{id}"
+  	  "rel":"self",
+  	  "href":"{id}"
   	}
   ]
 }
@@ -820,16 +820,14 @@ For example, if a hyper schema was defined:
 </figure>
 And a resource was requested from somesite.com:
     <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 GET /foo/
 ]]></artwork>
 </figure>
 
 With a response of:
     <figure>
-        <artwork>
-        <![CDATA[
+        <artwork><![CDATA[
 Content-Type: application/json; profile=/schema-for-this-data
 [
   {"id":"bar", "name":"This representation can be safely treated \
@@ -848,7 +846,7 @@ Content-Type: application/json; profile=/schema-for-this-data
 </section>
 <section title="IANA Considerations">
 <t>
-   The proposed MIME media type for JSON Schema is application/schema+json
+   The proposed MIME media type for JSON Schema is "application/schema+json".
 </t>
 <t>
    Type name: application
@@ -876,9 +874,9 @@ Content-Type: application/json; profile=/schema-for-this-data
 
 <section title="Registry of Link Relations">
 <t>
-This registry is maintained by IANA per RFC 4287 and this specification adds
+This registry is maintained by IANA per <xref target='RFC4287'>RFC 4287</xref> and this specification adds
 four values: "full", "create", "instances", "root".  New
-   assignments are subject to IESG Approval, as outlined in [RFC5226].
+   assignments are subject to IESG Approval, as outlined in <xref target='RFC5226'>RFC 5226</xref>.
    Requests should be made by email to IANA, which will then forward the
    request to the IESG, requesting approval.
 
@@ -893,16 +891,17 @@ four values: "full", "create", "instances", "root".  New
 
 
     <references title="Normative References">
-      &rfc3986;
-      &rfc2119;
-      &rfc4287;
-      &rfc3339;
       &rfc2045;
+      &rfc2119;
+      &rfc2396;
+      &rfc3339;
+      &rfc3986;
+      &rfc4287;
     </references>
 
     <references title="Informative References">
-      &rfc4627;
       &rfc2616;
+      &rfc4627;
       &rfc5226;
       &iddiscovery;
       &uritemplate;
@@ -919,70 +918,62 @@ instead of numbers</t>
 </section>
 -->
 
-    <section title="Change Log ">
-          <t>-03</t>
-          <t>
+    <section title="Change Log">
+      <t>
+        <list style="hanging">
+          <t hangText="draft-03">
             <list style="symbols">
-              <t>Defined referencing schemas by URI for all elements that accept schemas</t>
-              <t>Added example and verbiage to extends</t>
-              <t>Defined slash-delimited to use a leading slash</t>
-              <t>Made "root" a relation instead of an attribute</t>
-              <t>Removed address values, and mime media type from format to reduce confusion (mediaType already exists, so it can be used for MIME types)</t>
+              <t>Defined referencing schemas by URI for all elements that accept schemas.</t>
+              <t>Added example and verbiage to "extends" attribute.</t>
+              <t>Defined slash-delimited to use a leading slash.</t>
+              <t>Made "root" a relation instead of an attribute.</t>
+              <t>Removed address values, and MIME media type from format to reduce confusion (mediaType already exists, so it can be used for MIME types).</t>
               <t>Added more explanation of nullability.</t>
               <t>Removed "alternate" attribute.</t>
               <t>Upper cased many normative usages of must, may, and should.</t>
-              <t>Replaced divisibleBy attribute with maxDecimal attribute</t>
-              <t>Replaced optional attribute with required attribute</t>
-              <t>Replaced maximumCanEqual attribute with exclusiveMaximum attribute</t>
-              <t>Replaced minimumCanEqual attribute with exclusiveMinimum attribute</t>
-              <t>Moved default and contentEncoding to hyper schema</t>
-              <t>Added additionalItems</t>
-              <t>Added id</t>
-              <t>Switched self-referencing variable substitution from "-this" to "@" to align with reserved characters in URI template</t>
+              <t>Replaced "divisibleBy" attribute with "maxDecimal" attribute.</t>
+              <t>Replaced "optional" attribute with "required" attribute.</t>
+              <t>Replaced "maximumCanEqual" attribute with "exclusiveMaximum" attribute.</t>
+              <t>Replaced "minimumCanEqual" attribute with "exclusiveMinimum" attribute.</t>
+              <t>Moved "default" and "contentEncoding" attributes to hyper schema</t>
+              <t>Added "additionalItems" attribute.</t>
+              <t>Added "id" attribute.</t>
+              <t>Switched self-referencing variable substitution from "-this" to "@" to align with reserved characters in URI template.</t>
               
             </list>
           </t>
-          <t>-02</t>
-          <t>
+          <t hangText="draft-02">
             <list style="symbols">
-              <t>Replaced maxDecimal attribute with divisibleBy attribute</t>
+              <t>Replaced "maxDecimal" attribute with "divisibleBy" attribute.</t>
               <t>Added slash-delimited fragment resolution protocol and made it the default.</t>
               <t>Added language about using links outside of schemas by referencing it's normative URI.</t>
-              <t>Added uniqueItems attribute</t>
-              <t>Added targetSchema attribute to link description object</t>
+              <t>Added "uniqueItems" attribute.</t>
+              <t>Added "targetSchema" attribute to link description object.</t>
               
             </list>
           </t>
-          <t>-01</t>
-          <t>
+          <t hangText="draft-01">
             <list style="symbols">
-              <t>Fixed category and updates from template</t>
+              <t>Fixed category and updates from template.</t>
             </list>
           </t>
-          <t>-00</t>
-          <t>
+          <t hangText="draft-00">
             <list style="symbols">
-              <t>Initial draft</t>
+              <t>Initial draft.</t>
             </list>
           </t>
-
+        </list>
+      </t>
     </section>
 
     <section title="Open Issues">
+      <list>
       <t>Should we give a preference to MIME headers over Link headers (or only use one)?</t>
-      <t>Should we use "profile" as the media type parameter instead?</t>
-      <t>Should "root" be a MIME parameter instead of a schema attribute?</t>
-      <t>Should "format" be renamed to "mediaType" or "contentType" to reflect the usage MIME media types that are allowed.</t>
-      <t>I still do not like how dates are handled.</t>
-      <t>Should "slash-delimited" or "dot-delimited" be the default fragment resolution protocol?</t>
-
+      <t>Should "root" be a MIME parameter?</t>
+      <t>Should "format" be renamed to "mediaType" or "contentType" to reflect the usage MIME media types that are allowed?</t>
+      <t>How should dates be handled?</t>
+      </list>
     </section>
-
-    <!--
-$Log: draft-zyp-json-schema.xml,v $
-Revision 0.1  2009/09/25 02:46:57  H73653
-*** empty log message ***
-	place for source control log here
-  -->
+    
   </back>
 </rfc>


### PR DESCRIPTION
This patch doesn't add any features to the specification. Instead, I went through and fixed various wordings, corrected and added some XML structure, added consistency, etc. Overall, I tried to improve what was already there. A detailed list of what I changed is below:

-Added RFC2396 reference
-Quoted MIME types
-Added reference targets to all mentionings of RFCs
-Improved artwork spacing, updated all JSON examples to use consistent spacing
-Added external references to URLs
-Improved wording to:
--Core Schema Definition
--required
--requires
--minimum
--maximum
--exclusiveMaximum
--exclusiveMinimum
--minItems
--maxItems
--uniqueItems
--pattern
--maxLength
--minLength
--enum
--title
--description
--id
--targetSchema
--method
--readonly
--contentEncoding
--default
-Lists now use hanging style where appropriate
-Moved "root" link under instance links
-Fixed list layout for rel
-Fixed sectioning of targetSchema
-Cleaned up changelog
-Removed no longer outstanding open issues
-Added recognition of work
