### PR TITLE
Fix #16

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -113,8 +113,8 @@ var validate = exports._validate = function(/*Any*/instance,/*Object*/schema,/*O
 			return [];
 		}
 		if(value === undefined){
-			if(!schema.optional && !schema.get){
-				addError("is missing and it is not optional");
+			if(schema.required){
+				addError("is missing and it is required");
 			}
 		}else{
 			errors = errors.concat(checkType(schema.type,value));


### PR DESCRIPTION
Make required semantics compatible with current draft.

Support for optional is retained, but without either optional or required, properties are assumed not to be required (as opposed to assumed not to be optional).
