### PR TITLE
Fix package.json so it can be installed via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "url":"http://github.com/kriszyp/json-schema"
   },
   "directories": { "lib": "./lib" },
-  "main": ["./lib/validate.js", "./lib/links.js"]
+  "main": "./lib/validate.js"
 }


### PR DESCRIPTION
Simple fix to make it installable by npm, though it could be better to expose links.js too
