### PR TITLE
fix error message when extra properties are passed

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -218,7 +218,7 @@ var validate = exports._validate = function(/*Any*/instance,/*Object*/schema,/*O
 					delete instance[i];
 					continue;
 				} else {
-					errors.push({property:path,message:(typeof value) + "The property " + i +
+					errors.push({property:path,message:"The property " + i +
 						" is not defined in the schema and the schema does not allow additional properties"});
 				}
 			}


### PR DESCRIPTION
I was getting an error message formatted as:

```
booleanThe property anExtraOption is not defined in the schema and the schema does not allow additional properties
```

...which is clearly not right
