### PR TITLE
Use an SPDX license expression for license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,7 @@
     "json",
     "schema"
   ],
-  "licenses": [
-     {
-         "type": "AFLv2.1",
-         "url": "http://trac.dojotoolkit.org/browser/dojo/trunk/LICENSE#L43"
-     },
-     {
-         "type": "BSD",
-         "url": "http://trac.dojotoolkit.org/browser/dojo/trunk/LICENSE#L13"
-     }
-  ],
+  "license": "(AFL-2.1 OR BSD-3-Clause)",
   "repository": {
     "type":"git",
     "url":"http://github.com/kriszyp/json-schema"


### PR DESCRIPTION
This tiny pull request replaces the Ruby-style `licenses` property currently in `package.json` with a `license` property and SPDX license expression in line with [npm's guidelines for package.json](https://docs.npmjs.com/files/package.json#license).

The dual licensing situation is unusualy, but SPDX expressions are very well suited to handle. The expression in this pull request references the two licenses described [on Dojo's licensing page](http://dojotoolkit.org/reference-guide/1.7/quickstart/introduction/licensing.html), the [Academic Free License, version 2.1](http://spdx.org/licenses/AFL-2.1.html) and the [three-clause "new" BSD license](http://spdx.org/licenses/BSD-3-Clause.html).

Thanks so much for `json-schema`, which I've used as often as possible in my own projects. It's a great "infrastructure" library---the kind of thing all involved should really be proud of, even if it's sometimes hard to explain :wink:
