### PR TITLE
update package.json to include valid license urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "licenses": [
      {
          "type": "AFLv2.1",
-         "url": "http://trac.dojotoolkit.org/browser/dojo/trunk/LICENSE#L43"
+         "url": "https://github.com/dojo/dojo/blob/master/LICENSE#L43"
      },
      {
          "type": "BSD",
-         "url": "http://trac.dojotoolkit.org/browser/dojo/trunk/LICENSE#L13"
+         "url": "https://github.com/dojo/dojo/blob/master/LICENSE#L13"
      }
   ],
   "repository": {


### PR DESCRIPTION
migrate from http://trac.dojotoolkit.org to https://github.com/dojo/dojo/
