### PR TITLE
Clean up error message for additionalProperties: false

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -218,7 +218,7 @@ var validate = exports._validate = function(/*Any*/instance,/*Object*/schema,/*O
 					delete instance[i];
 					continue;
 				} else {
-					errors.push({property:path,message:(typeof value) + "The property " + i +
+					errors.push({property:path,message:"The property " + i +
 						" is not defined in the schema and the schema does not allow additional properties"});
 				}
 			}


### PR DESCRIPTION
Cleaned up the error message for when unknown properties are found and `additionalProperties` is set to false.

This piece of code didn't seem to serve any purpose so I removed it. It always generates an error message like "stringThe parameter ..." because the `value` variable comes from somewhere else earlier in the function.
