### PR TITLE
Correct Licence Names to SPDX

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   ],
   "licenses": [
      {
-         "type": "AFLv2.1",
+         "type": "AFL-2.1",
          "url": "https://github.com/dojo/dojo/blob/master/LICENSE"
      },
      {
-         "type": "BSD 3-Clause",
+         "type": "BSD-3-Clause",
          "url": "https://github.com/dojo/dojo/blob/master/LICENSE"
      }
   ],


### PR DESCRIPTION
This helps many legal tools around npm how to handle the license of this package.