### PR TITLE
Updating deprecated licenses field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,7 @@
     "json",
     "schema"
   ],
-  "licenses": [
-     {
-         "type": "AFLv2.1",
-         "url": "https://github.com/dojo/dojo/blob/master/LICENSE"
-     },
-     {
-         "type": "BSD 3-Clause",
-         "url": "https://github.com/dojo/dojo/blob/master/LICENSE"
-     }
-  ],
+  "license": "(AFL-2.1 OR BSD-3-Clause)",
   "repository": {
     "type":"git",
     "url":"http://github.com/kriszyp/json-schema"


### PR DESCRIPTION
Hi, 
"licenses" field is deprecated in favor of a "license" field with an SPDX expression (see https://docs.npmjs.com/files/package.json#license).
And the expression adds the benefit or removing ambiguity on the combination of licenses (OR/AND).
Thanks, 
Camille 