### PR TITLE
Updated LICENSE text to use SPDX license identifiers where applicable

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,16 @@
-Dojo is available under *either* the terms of the modified BSD license *or* the
+Dojo is available under *either* the terms of the BSD 3-Clause "New" License *or* the
 Academic Free License version 2.1. As a recipient of Dojo, you may choose which
 license to receive this code under (except as noted in per-module LICENSE
 files). Some modules may not be the copyright of the Dojo Foundation. These
 modules contain explicit declarations of copyright in both the LICENSE files in
 the directories in which they reside and in the code itself. No external
 contributions are allowed under licenses which are fundamentally incompatible
-with the AFL or BSD licenses that Dojo is distributed under.
+with the AFL-2.1 OR and BSD-3-Clause licenses that Dojo is distributed under.
 
-The text of the AFL and BSD licenses is reproduced below. 
+The text of the AFL-2.1 and BSD-3-Clause licenses is reproduced below. 
 
 -------------------------------------------------------------------------------
-The "New" BSD License:
+BSD 3-Clause "New" License:
 **********************
 
 Copyright (c) 2005-2015, The Dojo Foundation


### PR DESCRIPTION
HI @kriszyp - Thank you for merging the license text from #61. Since that PR was relatively stale, I've updated the license text to use the `SPDX` license identifiers where applicable. 

If merged, I would also request that a `npm version patch` be performed and published to the registry. 