### PR TITLE
Use Object.prototype.hasOwnProperty.call instead of calling object method

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -207,8 +207,8 @@ var validate = exports._validate = function(/*Any*/instance,/*Object*/schema,/*O
 			}
 			
 			for(var i in objTypeDef){ 
-				if(objTypeDef.hasOwnProperty(i) && i != '__proto__' && i != 'constructor'){
-					var value = instance.hasOwnProperty(i) ? instance[i] : undefined;
+				if(Object.prototype.hasOwnProperty.call(objTypeDef, i) && i != '__proto__' && i != 'constructor'){
+					var value = Object.prototype.hasOwnProperty.call(instance, i) ? instance[i] : undefined;
 					// skip _not_ specified properties
 					if (value === undefined && options.existingOnly) continue;
 					var propDef = objTypeDef[i];
@@ -224,7 +224,7 @@ var validate = exports._validate = function(/*Any*/instance,/*Object*/schema,/*O
 			}
 		}
 		for(i in instance){
-			if(instance.hasOwnProperty(i) && !(i.charAt(0) == '_' && i.charAt(1) == '_') && objTypeDef && !objTypeDef[i] && additionalProp===false){
+			if(Object.prototype.hasOwnProperty.call(instance, i) && !(i.charAt(0) == '_' && i.charAt(1) == '_') && objTypeDef && !objTypeDef[i] && additionalProp===false){
 				if (options.filter) {
 					delete instance[i];
 					continue;

--- a/test/tests.js
+++ b/test/tests.js
@@ -117,5 +117,37 @@ var suite = vows.describe('JSON Schema').addBatch({
         const a = {};
         validate(instance);
         assert.equal(a.polluted, undefined);
-    }
+    },
+    'validation of object with overridden hasOwnProperty does not throw': function() {
+        const schema = {
+            type: 'object',
+            properties: {
+                property: {
+                    type: 'string',
+                }
+            },
+        };
+
+        const instance = { hasOwnProperty: true };
+        assert.doesNotThrow(function() {
+            validate(instance, schema);
+        });
+    },
+    'validation of object with null prototype does not throw': function() {
+        const schema = {
+            type: 'object',
+            properties: {
+                property: {
+                    type: 'string',
+                }
+            },
+        };
+
+        const instance = Object.assign(Object.create(null), {
+            property: "value"
+        });
+        assert.doesNotThrow(function() {
+            validate(instance, schema);
+        });
+    },
 }).export(module);


### PR DESCRIPTION
Given how widely used this package is, likely sometimes on untrusted data, despite other alternatives being recommended, I figured this would be worth a fix.

Using `obj.hasOwnProperty()` is rarely, if ever, a good idea. Similarly, overriding `hasOwnProperty` is rarely a good idea, but you can't always avoid input that would do this. Looking at the recent prototype pollution fixes, I noticed that this package calls `hasOwnProperty()` directly on objects in a few places, most critically on objects being validated.

Have a look at the tests to see what the issue is. Passing an object that overrides `hasOwnProperty` will cause `validate` to call that instead of `Object.prototype.hasOwnProperty`. Additionally, objects not inheriting from `Object.prototype` will fail validation due to the same issue. Have a look at the tests for details.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty#using_hasownproperty_as_a_property_name