### PR TITLE
chore: add release and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: publish
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  tests:
+    uses: brickhouse-tech/.github/.github/workflows/tests.yml@main
+    with:
+      node-versions: '["18.x", "20.x", "22.x"]'
+  publish:
+    needs: [tests]
+    uses: brickhouse-tech/.github/.github/workflows/publish.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: release
+on:
+  push:
+    branches: ["master"]
+    tags-ignore: ['**']
+jobs:
+  tests:
+    uses: brickhouse-tech/.github/.github/workflows/tests.yml@main
+    with:
+      node-versions: '["18.x", "20.x", "22.x"]'
+  release:
+    needs: [tests]
+    uses: brickhouse-tech/.github/.github/workflows/release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Adds release (commit-and-tag-version + push tags) and publish (OIDC npm) workflows using shared brickhouse-tech/.github reusable workflows. CI tests already wired up.