### PR TITLE
chore: rename to @brickhouse-tech/json-schema-lts + shared workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "json-schema-lts",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  push:
+    branches: [master, security/*]
+  pull_request:
+    branches: [master]
+
+jobs:
+  tests:
+    uses: brickhouse-tech/.github/.github/workflows/tests.yml@main
+    with:
+      node-versions: '["18.x", "20.x", "22.x"]'
+      lint: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: publish
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  tests:
+    uses: brickhouse-tech/.github/.github/workflows/tests.yml@main
+    with:
+      node-versions: '["20.x"]'
+  publish:
+    needs: [tests]
+    uses: brickhouse-tech/.github/.github/workflows/publish.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: release
+on:
+  push:
+    branches: ["master"]
+    tags-ignore: ['**']
+jobs:
+  tests:
+    uses: brickhouse-tech/.github/.github/workflows/tests.yml@main
+    with:
+      node-versions: '["20.x"]'
+  release:
+    needs: [tests]
+    uses: brickhouse-tech/.github/.github/workflows/release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 yarn.lock
-.vscode
+.vscodenode_modules/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
-This is a historical repository for the early development of the JSON Schema specification and implementation. This package is considered "finished": it holds the earlier draft specification and a simple, efficient, lightweight implementation of the original core elements of JSON Schema. This repository does not house the latest specifications nor does it implement the latest versions of JSON Schema. This package seeks to maintain the stability (in behavior and size) of this original implementation for the sake of the numerous packages that rely on it. For the latest JSON Schema specifications and implementations, please visit the [JSON Schema site](https://json-schema.org/) (or the [respository](https://github.com/json-schema-org/json-schema-spec)).
+# json-schema (LTS Security Fork)
+
+> **⚠️ This is a community-maintained LTS fork of [`json-schema`](https://github.com/kriszyp/json-schema) with critical security patches.**
+
+The upstream package has 28M+ weekly downloads but has not published a release since the critical prototype pollution vulnerability (CVE-2021-3918, CVSS 9.8) was fixed in source. This fork exists to provide those fixes in a publishable package.
+
+## Security Fixes
+
+| CVE | Severity | Description | Status |
+|-----|----------|-------------|--------|
+| [CVE-2021-3918](https://nvd.nist.gov/vuln/detail/CVE-2021-3918) | **Critical (9.8)** | Prototype pollution via `__proto__` and `constructor` in schema validation | ✅ Fixed |
+
+## Installation
+
+```bash
+npm install @brickhouse-tech/json-schema
+```
+
+## About
+
+This is a historical repository for the early development of the JSON Schema specification and implementation. This package is considered "finished": it holds the earlier draft specification and a simple, efficient, lightweight implementation of the original core elements of JSON Schema. This repository does not house the latest specifications nor does it implement the latest versions of JSON Schema. This package seeks to maintain the stability (in behavior and size) of this original implementation for the sake of the numerous packages that rely on it. For the latest JSON Schema specifications and implementations, please visit the [JSON Schema site](https://json-schema.org/) (or the [repository](https://github.com/json-schema-org/json-schema-spec)).
+
+## LTS Maintenance
+
+This fork is maintained by [Brickhouse Tech](https://github.com/brickhouse-tech) for the purpose of shipping security patches to the millions of projects that depend on this package.
+
+**We do not add features.** We only:
+- Backport and publish security fixes
+- Keep CI and tooling current
+- Respond to new CVEs
+
+If this package saves your team from a compliance headache, consider supporting continued maintenance:
+
+💖 [**GitHub Sponsors**](https://github.com/sponsors/brickhouse-tech)
+
+## License
 
 Code is licensed under the AFL or BSD 3-Clause license.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,30 @@
+import js from "@eslint/js";
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "commonjs",
+      globals: {
+        module: "readonly",
+        exports: "writable",
+        require: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        console: "readonly",
+        define: "readonly",
+        process: "readonly",
+      },
+    },
+    rules: {
+      "no-prototype-builtins": "error",
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^(suite|assertValidates)$" }],
+      "no-redeclare": "warn",
+      "no-useless-escape": "warn",
+    },
+  },
+  {
+    ignores: ["draft-*/**"],
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema",
-  "version": "0.4.0",
+  "version": "0.4.1-lts.0",
   "author": "Kris Zyp",
   "description": "JSON Schema validation and specifications",
   "maintainers":[
@@ -19,6 +19,6 @@
   },
   "directories": { "lib": "./lib" },
   "main": "./lib/validate.js",
-  "devDependencies": { "vows": "*" },
-  "scripts": { "test": "vows --spec test/*.js" }
+  "devDependencies": { "vows": "*", "@eslint/js": "^9.0.0", "eslint": "^9.0.0" },
+  "scripts": { "test": "vows --spec test/*.js", "lint": "eslint lib/ test/" }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
-  "name": "json-schema",
-  "version": "0.4.1-lts.0",
+  "name": "@brickhouse-tech/json-schema-lts",
+  "version": "0.4.1-0",
   "author": "Kris Zyp",
   "description": "JSON Schema validation and specifications",
-  "maintainers":[
-  	{"name": "Kris Zyp", "email": "kriszyp@gmail.com"}],
+  "maintainers": [
+    {
+      "name": "Brickhouse Tech",
+      "email": "zbricktarz@gmail.com"
+    }
+  ],
   "keywords": [
     "json",
     "schema"
@@ -14,11 +18,20 @@
   ],
   "license": "(AFL-2.1 OR BSD-3-Clause)",
   "repository": {
-    "type":"git",
-    "url":"http://github.com/kriszyp/json-schema"
+    "type": "git",
+    "url": "https://github.com/brickhouse-tech/json-schema.git"
   },
-  "directories": { "lib": "./lib" },
+  "directories": {
+    "lib": "./lib"
+  },
   "main": "./lib/validate.js",
-  "devDependencies": { "vows": "*", "@eslint/js": "^9.0.0", "eslint": "^9.0.0" },
-  "scripts": { "test": "vows --spec test/*.js", "lint": "eslint lib/ test/" }
+  "devDependencies": {
+    "vows": "*",
+    "@eslint/js": "^9.0.0",
+    "eslint": "^9.0.0"
+  },
+  "scripts": {
+    "test": "vows --spec test/*.js",
+    "lint": "eslint lib/ test/"
+  }
 }


### PR DESCRIPTION
Prepares json-schema for first npm publish under the brickhouse-tech scope.

**Changes:**
- Package renamed: `json-schema` → `@brickhouse-tech/json-schema-lts`
- Version: `0.4.1-0` (prerelease — includes CVSS 9.8 prototype pollution fix never published upstream)
- Repository URL → `brickhouse-tech/json-schema` (required for OIDC provenance)
- CI, release, publish workflows using shared `brickhouse-tech/.github`

**Context:**
- Upstream `json-schema` has 28.9M weekly downloads
- CVSS 9.8 prototype pollution fix exists but was never published
- This is the LTS security patches business play

**First publish:** Local `npm publish --access public --auth-type=web` then configure trusted publishing on npmjs.com.